### PR TITLE
Use SECRET_KEY env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ Progetto Python per registrare, analizzare e prevedere incidenti sul lavoro nei 
 
 ## Requisiti
 Vedi `requirements.txt`
+
+Prima di avviare l'applicazione è necessario definire la variabile
+d'ambiente `SECRET_KEY` che verrà utilizzata da Flask per firmare i cookie
+di sessione.
+
+Esempio:
+
+```bash
+export SECRET_KEY="valore-sicuro"
+python run.py
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 from flask import Flask
+import os
 
 app = Flask(__name__)
-app.secret_key = "chiave-segreta"
+app.secret_key = os.getenv("SECRET_KEY", os.urandom(24))
 from app import routes


### PR DESCRIPTION
## Summary
- load Flask secret key from env var with a safe fallback
- document how to set `SECRET_KEY` before running the app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f5e57b208323945fa90971bdc184