### PR TITLE
Fix dashboard paths

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -50,8 +50,8 @@ def dashboard():
     import matplotlib.pyplot as plt
 
     # Percorsi
-    csv_path = os.path.join(os.getcwd(), "data", "incidents.csv")
-    static_path = os.path.join(os.getcwd(), "static")
+    csv_path = CSV_PATH
+    static_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static"))
 
     print("📂 CSV path:", csv_path)
     print("📂 Static path:", static_path)


### PR DESCRIPTION
## Summary
- use `CSV_PATH` constant inside dashboard route
- compute `static_path` from the file location

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run.py` (fails without dependencies, install dependencies and run)


------
https://chatgpt.com/codex/tasks/task_e_6841f74e35e883239982ddf6ec57705f