### PR TITLE
Add yearly incident stats

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -83,4 +83,17 @@ def dashboard():
     plt.close(fig2)
     print(f"✅ Grafico 2 salvato in: {grav_path}")
 
+    # Grafico Anno
+    df['Data'] = pd.to_datetime(df['Data'], errors='coerce')
+    fig3 = plt.figure()
+    df['Data'].dt.year.value_counts().sort_index().plot(kind='bar')
+    plt.title("Incidenti per Anno")
+    plt.ylabel("Numero")
+    plt.xticks(rotation=45)
+    fig3.tight_layout()
+    year_path = os.path.join(static_path, "grafico_anno.png")
+    fig3.savefig(year_path)
+    plt.close(fig3)
+    print(f"✅ Grafico 3 salvato in: {year_path}")
+
     return render_template("dashboard.html")

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -12,6 +12,9 @@
     <h2>Grafico Gravità</h2>
     <img src="{{ url_for('static', filename='grafico_gravita.png') }}" alt="Grafico Gravità"><br><br>
 
+    <h2>Grafico per Anno</h2>
+    <img src="{{ url_for('static', filename='grafico_anno.png') }}" alt="Grafico Anno"><br><br>
+
     <a href="/">🔙 Torna alla Home</a>
 </body>
 </html>

--- a/scripts/analizza_incidenti.py
+++ b/scripts/analizza_incidenti.py
@@ -37,3 +37,19 @@ plt.ylabel("Numero di incidenti")
 plt.xticks(rotation=45)
 plt.tight_layout()
 plt.show()
+
+# --- Analisi per anno ---
+df['Data'] = pd.to_datetime(df['Data'], errors='coerce')
+by_year = df['Data'].dt.year.value_counts().sort_index()
+
+print("\n📈 Incidenti per anno:")
+print(by_year)
+
+plt.figure(figsize=(8, 5))
+by_year.plot(kind='bar')
+plt.title("Incidenti per Anno")
+plt.xlabel("Anno")
+plt.ylabel("Numero di incidenti")
+plt.xticks(rotation=45)
+plt.tight_layout()
+plt.show()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -56,3 +56,10 @@ else:  # Statistiche
         df['Gravità'].value_counts().plot(kind='pie', autopct='%1.1f%%')
         plt.tight_layout()
         st.pyplot(fig2)
+
+        st.subheader("Incidenti per Anno")
+        df['Data'] = pd.to_datetime(df['Data'], errors='coerce')
+        fig3 = plt.figure()
+        df['Data'].dt.year.value_counts().sort_index().plot(kind='bar')
+        plt.tight_layout()
+        st.pyplot(fig3)


### PR DESCRIPTION
## Summary
- analyze incidents per year in `analizza_incidenti.py`
- generate yearly chart in Flask dashboard
- show yearly stats in Streamlit app

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ffcfbae4832389e00292b8e613ec